### PR TITLE
Fixed invalid methods call

### DIFF
--- a/src/js/Bootstrap.ts
+++ b/src/js/Bootstrap.ts
@@ -26,7 +26,7 @@ jQuery.fn.slider = function (action:any, optValue:any):any {
 	}
 
 	this.each(function () {
-		var self = jQuery.slider(<HTMLInputElement>this, action, optValue);
+		var self = jQuery.slider(<HTMLInputElement>this, action);
 
 		// do actions
 		if (typeof action == "string") {


### PR DESCRIPTION
Because of optValue, slider instance was alwaye reinitionalizing.

For example
~~~TS
$("#selector").slider('value', 10, 20);
~~~

This code will apply `10` as `force` argument while extracting slider instance. And it will reinit slider.

P.S. Sorry for my Engrish