### PR TITLE
Fixed unconditional limit labels creation

### DIFF
--- a/src/js/Slider.ts
+++ b/src/js/Slider.ts
@@ -203,6 +203,10 @@ module Slider {
 		 * @returns {SliderLimitLabel}
 		 */
 		private createLimitLabels():void {
+			if (!this.settings.limits) {
+        			return;
+    			}
+    			
 			var template:string;
 			var params:Object;
 			var limitLabel:Slider.LimitLabel;


### PR DESCRIPTION
Because of this method adds limit labels without checking `this.settings.limits` option and add limit label element to the DOM, they are (limit labels) always appearing.